### PR TITLE
Ease external options for optimisation or hardening

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,35 +39,36 @@ VDB_LIB := -L $(VDB_PATH)/lib64
 NGS_INCL := -I $(NGS_PATH)/include
 NGS_LIB := -L $(NGS_PATH)/lib64
 
-CC = c++ -std=c++11 -fdiagnostics-color=never
-CFLAGS = -Wall -Wno-format-y2k  -pthread -fPIC -O3 -finline-functions -fstrict-aliasing \
-         -fomit-frame-pointer -msse4.2 $(BOOST_INCL) $(NGS_INCL) $(VDB_INCL)
+CC ?= c++
+CFLAGS ?= -O3 -finline-functions -fstrict-aliasing -fomit-frame-pointer -msse4.2 -fdiagnostics-color=never
+CFLAGS += -std=c++11
+CFLAGS += -Wall -Wno-format-y2k  -pthread -fPIC $(BOOST_INCL) $(NGS_INCL) $(VDB_INCL)
 
 PLATFORM=$(shell uname -s)
 
 ifeq ($(PLATFORM),Linux)
 
-LIBS = $(VDB_LIB) -lncbi-ngs-c++-static -lncbi-vdb-static \
-       $(NGS_LIB) -lngs-c++-static \
-       -Wl,-Bstatic $(BOOST_LIB) \
-       -lboost_program_options \
-       -lboost_iostreams \
-       -lboost_regex \
-       -lboost_timer \
-       -lboost_chrono \
-       -lboost_system \
-       -Wl,-Bdynamic -lrt -ldl -lm  -lpthread -lz
+LIBS += $(VDB_LIB) -lncbi-ngs-c++-static -lncbi-vdb-static \
+        $(NGS_LIB) -lngs-c++-static \
+        -Wl,-Bstatic $(BOOST_LIB) \
+        -lboost_program_options \
+        -lboost_iostreams \
+        -lboost_regex \
+        -lboost_timer \
+        -lboost_chrono \
+        -lboost_system \
+        -Wl,-Bdynamic -lrt -ldl -lm  -lpthread -lz
 
 else
 
-LIBS = $(BOOST_LIB) \
-       -lboost_program_options \
-       -lboost_iostreams \
-       -lboost_regex \
-       -lboost_timer \
-       -lboost_chrono \
-       -lboost_system \
-       -ldl -lm -lpthread -lz
+LIBS += $(BOOST_LIB) \
+        -lboost_program_options \
+        -lboost_iostreams \
+        -lboost_regex \
+        -lboost_timer \
+        -lboost_chrono \
+        -lboost_system \
+        -ldl -lm -lpthread -lz
 
 endif
 


### PR DESCRIPTION
CC should be reserved for the compiler, e.g. for an easy substitution with clang.
CFLAGS have a ?= default assignment to which extra flags are added with += that should not be required to be changed.
LIBS can be passed an initial value now, too.